### PR TITLE
add example for custom response stream

### DIFF
--- a/api2.md
+++ b/api2.md
@@ -662,6 +662,15 @@ ctx.response.res = { foo: 'bar' }
 ```js
 ctx.response.res = createResponseStream()
 ```
+**Example** *(CUSTOM RESPONSE STREAM calls)*  
+```js
+const Response = require('stream').Response;
+ctx.response.res = new Response({ object: true});
+ctx.response.res.push({ data: 'hello 1' });
+ctx.response.res.push({ data: 'hello 2' });
+ctx.response.res.push({ data: 'hello 3' });
+ctx.response.res.push(null);
+```
 **Example** *(DUPLEX calls)*  
 ```js
 ctx.response.res.write({ foo: 'bar' })


### PR DESCRIPTION
Created an example using custom npm module stream to help other developers implement their own solution. We just ran into this issue trying to get streaming from the server only setup.